### PR TITLE
Minor mod for getNodesForCompIDs

### DIFF
--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -376,8 +376,8 @@ class pyMeshLoader(BaseUI):
         nodeIDs : list
             List of unique nodeIDs that belong to the given list of compIDs
         """
-        # First determine the actual physical nodal location in the
-        # original BDF ordering of the nodes we want to add forces
+        # First determine the actual physical locations
+        # of the nodes we want to add forces
         # to. Only the root rank need do this:
         uniqueNodes = None
         if self.comm.rank == 0:
@@ -392,7 +392,7 @@ class pyMeshLoader(BaseUI):
 
         uniqueNodes = self.comm.bcast(uniqueNodes, root=0)
 
-        return uniqueNodes
+        return list(uniqueNodes)
 
     def getLocalNodeIDsForComps(self, componentIDs):
         """

--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -345,10 +345,6 @@ class pyMeshLoader(BaseUI):
         # Ensure input is list-like
         globalIDs = np.atleast_1d(globalIDs)
 
-        # Get the node id offset for this processor
-        OwnerRange = self.assembler.getOwnerRange()
-        nodeOffset = OwnerRange[self.comm.rank]
-
         # Get the local ID numbers for this proc
         tacsLocalIDs = []
         for gID in globalIDs:
@@ -361,6 +357,70 @@ class pyMeshLoader(BaseUI):
             tacsLocalIDs.append(lID)
 
         return tacsLocalIDs
+
+    def getGlobalNodeIDsForComps(self, componentIDs, nastranOrdering=False):
+        """
+        Return the global (non-partitioned) node IDs belonging to a given list of component IDs
+
+        Parameters
+        ----------
+        componentIDs : int or list[int]
+            List of integers of the compIDs numbers.
+
+        nastranOrdering : False
+            Flag signaling whether nodeIDs are in TACS (default) or NASTRAN (grid IDs in bdf file) ordering
+            Defaults to False.
+
+        Returns
+        -------
+        nodeIDs : list
+            List of unique nodeIDs that belong to the given list of compIDs
+        """
+        # Make sure list is flat
+        componentIDs = self._flatten(list(componentIDs))
+
+        # Get local element IDs on this processor that are in the component(s)
+        nodes = set()
+        elemIDs = self.getLocalElementIDsForComps(componentIDs)
+
+        # Add nodeIDs (global) from this processor's elements to the set
+        # Sets does not allow duplicate entries, so no nodeIDs are repeated
+        for eID in elemIDs:
+            nodes.update(self.assembler.getElementNodes(eID))
+
+        tacsNodeIDs = list(nodes)
+
+        if nastranOrdering:
+            return self.bdfInfo.node_ids[tacsNodeIDs]
+        else:
+            return tacsNodeIDs
+
+    def getLocalNodeIDsForComps(self, componentIDs):
+        """
+        return the local (partitioned) node IDs belonging to a given list of component IDs
+
+        Parameters
+        ----------
+        componentIDs : int or list[int]
+            List of integers of the compIDs numbers.
+
+        Returns
+        -------
+        nodeIDs : list
+            List of unique nodeIDs that belong to the given list of compIDs
+        """
+        # Get the global nodes for this component (TACS ordering)
+        globalNodeIDs = self.getGlobalNodeIDsForComps(
+            componentIDs, nastranOrdering=False
+        )
+
+        # convert global nodeIDs to local numbering on this processor if requested
+        rank = self.comm.rank
+        ownerRange = self.assembler.getOwnerRange()
+        allNodesOnProc = list(range(ownerRange[rank], ownerRange[rank + 1]))
+        nodes = [i for i, v in enumerate(allNodesOnProc) if v in globalNodeIDs]
+
+        return nodes
 
     def getGlobalElementIDsForComps(self, componentIDs, nastranOrdering=False):
         """

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -537,6 +537,30 @@ class pyTACS(BaseUI):
 
         return self.meshLoader.getGlobalNodeIDsForComps(compIDs)
 
+    def getLocalNodeIDsForComps(self, compIDs):
+        """
+        return the local (partitioned) node IDs belonging to a given list of component IDs
+
+        Parameters
+        ----------
+         compIDs : int or list[int] or None
+            List of integers of the compIDs numbers. If None, returns nodeIDs for all components.
+            Defaults to None.
+
+        Returns
+        -------
+        nodeIDs : list
+            List of unique nodeIDs that belong to the given list of compIDs
+        """
+        if self.assembler is None:
+            raise self._initializeError()
+
+        # Return all component ids
+        if compIDs is None:
+            compIDs = list(range(self.nComp))
+
+        return self.meshLoader.getLocalNodeIDsForComps(compIDs)
+
     def initialize(self, elemCallBack=None):
         """
         This is the 'last' method to be called during the setup. The

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -513,9 +513,9 @@ class pyTACS(BaseUI):
 
         return compDescripts
 
-    def getNodesForCompIDs(self, compIDs=None, returnLocal=False):
+    def getGlobalNodeIDsForComps(self, compIDs):
         """
-        Return a list of the unique nodeIDs belonging to a given list of compIDs
+        return the global (non-partitioned) node IDs belonging to a given list of component IDs
 
         Parameters
         ----------
@@ -523,44 +523,19 @@ class pyTACS(BaseUI):
             List of integers of the compIDs numbers. If None, returns nodeIDs for all components.
             Defaults to None.
 
-        returnLocal : bool
-            Flag to either return the global (non-partitioned) nodeIDs or determine the local nodeIDs on this processor.
-            Defaults to False.
-
         Returns
         -------
-        nodes : list
-            List of unique nodeIDs on this processor that belong to the given list of compIDs
+        nodeIDs : list
+            List of unique nodeIDs that belong to the given list of compIDs
         """
+        if self.assembler is None:
+            raise self._initializeError()
+
         # Return all component ids
         if compIDs is None:
             compIDs = list(range(self.nComp))
-        # Convert to list
-        elif isinstance(compIDs, int):
-            compIDs = [compIDs]
-        # Make sure list is flat
-        else:
-            compIDs = self._flatten(compIDs)
 
-        # Get local element IDs on this processor that are in the component(s)
-        nodes = set()
-        elemIDs = self.meshLoader.getLocalElementIDsForComps(compIDs)
-
-        # Add nodeIDs (global) from this processor's elements to the set
-        # Sets does not allow duplicate entries, so no nodeIDs are repeated
-        for eID in elemIDs:
-            nodes.update(self.assembler.getElementNodes(eID))
-
-        # convert global nodeIDs to local numbering on this processor if requested
-        if returnLocal:
-            # nodes = self.meshLoader.getLocalNodeIDsFromGlobal(list(nodes)) # does not work?
-            ownerRange = self.assembler.getOwnerRange()
-            allNodesOnProc = list(
-                range(ownerRange[self.rank], ownerRange[self.rank + 1])
-            )
-            nodes = [i for i, v in enumerate(allNodesOnProc) if v in nodes]
-
-        return list(nodes)
+        return self.meshLoader.getGlobalNodeIDsForComps(compIDs)
 
     def initialize(self, elemCallBack=None):
         """

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -513,7 +513,7 @@ class pyTACS(BaseUI):
 
         return compDescripts
 
-    def getGlobalNodeIDsForComps(self, compIDs):
+    def getGlobalNodeIDsForComps(self, compIDs, nastranOrdering=False):
         """
         return the global (non-partitioned) node IDs belonging to a given list of component IDs
 
@@ -522,6 +522,10 @@ class pyTACS(BaseUI):
         compIDs : int or list[int] or None
             List of integers of the compIDs numbers. If None, returns nodeIDs for all components.
             Defaults to None.
+
+        nastranOrdering : False
+            Flag signaling whether nodeIDs are in TACS (default) or NASTRAN (grid IDs in bdf file) ordering
+            Defaults to False.
 
         Returns
         -------
@@ -535,7 +539,7 @@ class pyTACS(BaseUI):
         if compIDs is None:
             compIDs = list(range(self.nComp))
 
-        return self.meshLoader.getGlobalNodeIDsForComps(compIDs)
+        return self.meshLoader.getGlobalNodeIDsForComps(compIDs, nastranOrdering)
 
     def getLocalNodeIDsForComps(self, compIDs):
         """


### PR DESCRIPTION
- Minor modifications for smdogroup/tacs#145:
   - Moving method to meshloader
   - Splitting into two methods (one for returning local nodes and one for global)
   - re-implementing addLoadToComps using new method